### PR TITLE
Feature/vtn 20075 fix openalpr cannot create assets causing by engine toolkit

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -258,13 +258,12 @@ func (e *Engine) processMessageMediaChunk(ctx context.Context, msg *sarama.Consu
 			return errors.Errorf("%d: %s", resp.StatusCode, buf.String())
 		}
 		e.logDebug("Toolkit got output from openalpr", buf.String())
-		if buf.Len() > 0 {
-			if err := json.NewDecoder(&buf).Decode(&engineOutputContent); err != nil {
-				return errors.Wrap(err, "decode response")
-			}
-		} else { // This prevent toolkit sending null data to Kafka
+		if buf.Len() == 0 {
 			ignoreChunk = true
 			return nil
+		}
+		if err := json.NewDecoder(&buf).Decode(&engineOutputContent); err != nil {
+			return errors.Wrap(err, "decode response")
 		}
 		return nil
 	})

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -175,6 +175,7 @@ func TestReadinessContextCancelled(t *testing.T) {
 	defer cancel()
 	err := engine.ready(ctx)
 	is.Equal(err, context.DeadlineExceeded)
+
 }
 
 func TestSubprocess(t *testing.T) {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -345,40 +345,6 @@ func TestSubprocessCrash(t *testing.T) {
 
 }
 
-type engineOutput struct {
-	// SourceEngineID   string         `json:"sourceEngineId,omitempty"`
-	// SourceEngineName string         `json:"sourceEngineName,omitempty"`
-	// TaskPayload      payload        `json:"taskPayload,omitempty"`
-	// TaskID           string         `json:"taskId"`
-	// EntityID         string         `json:"entityId,omitempty"`
-	// LibraryID        string         `json:"libraryId"`
-	Series []seriesObject `json:"series"`
-}
-
-type seriesObject struct {
-	Start     int    `json:"startTimeMs"`
-	End       int    `json:"stopTimeMs"`
-	EntityID  string `json:"entityId"`
-	LibraryID string `json:"libraryId"`
-	Object    object `json:"object"`
-}
-
-type object struct {
-	Label        string   `json:"label"`
-	Text         string   `json:"text"`
-	ObjectType   string   `json:"type"`
-	URI          string   `json:"uri"`
-	EntityID     string   `json:"entityId,omitempty"`
-	LibraryID    string   `json:"libraryId,omitempty"`
-	Confidence   float64  `json:"confidence"`
-	BoundingPoly []coords `json:"boundingPoly"`
-}
-
-type coords struct {
-	X float64 `json:"x"`
-	Y float64 `json:"y"`
-}
-
 type engineOutputMessage struct {
 	Type          messageType `json:"type"`
 	TimestampUTC  int64       `json:"timestampUTC"`


### PR DESCRIPTION
When upgrading openalpr engine to use the latest code of engine-toolkit. I encountered this bug https://steel-ventures.atlassian.net/projects/VTN/issues/VTN-20075. 

I tried at https://github.com/veritone/task-openalpr-enginetoolkit-chunk-go/blob/feature/VTN_20075_Fix_Openalpr_can_not_create_assets/main.go#L162 with [json.NewEncoder(w).Encode(resp) or w.Write(res)] but both did not work. edge_output_writer reported json encode error when creating vtnStandard.