### PR TITLE
[IN TEST] Timing events

### DIFF
--- a/engine/config.go
+++ b/engine/config.go
@@ -10,8 +10,11 @@ import (
 
 // Config holds engine configuration settings.
 type Config struct {
+	// Engine contains engine specific configuration and information.
 	Engine struct {
-		ID         string
+		// ID is the identifier for this engine.
+		ID string
+		// InstanceID is the instance ID for this running instance.
 		InstanceID string
 		// EndIfIdleDuration is the duration after the last message
 		// at which point the engine will shut down.
@@ -74,7 +77,10 @@ type Config struct {
 			MaxBackoffDuration time.Duration
 		}
 	}
+	// Events contains system event configuration.
 	Events struct {
+		// PeriodicUpdateDuration is the interval at which to
+		// send periodic updates during processing.
 		PeriodicUpdateDuration time.Duration
 	}
 }

--- a/engine/config_test.go
+++ b/engine/config_test.go
@@ -12,12 +12,16 @@ import (
 // Default values are set in NewConfig.
 func TestNewConfig(t *testing.T) {
 	is := is.New(t)
+
 	os.Setenv("VERITONE_WEBHOOK_READY", "http://0.0.0.0:8080/readyz")
 	os.Setenv("VERITONE_WEBHOOK_PROCESS", "http://0.0.0.0:8080/process")
 	os.Setenv("KAFKA_BROKERS", "0.0.0.0:9092,1.1.1.1:9092")
 	os.Setenv("KAFKA_INPUT_TOPIC", "input-topic")
 	os.Setenv("KAFKA_CONSUMER_GROUP", "consumer-group")
 	os.Setenv("END_IF_IDLE_SECS", "60")
+
+	os.Setenv("ENGINE_INSTANCE_ID", "instance1")
+	os.Setenv("ENGINE_ID", "engine1")
 
 	config := NewConfig()
 	is.Equal(config.Webhooks.Ready.URL, "http://0.0.0.0:8080/readyz")
@@ -27,7 +31,11 @@ func TestNewConfig(t *testing.T) {
 	is.Equal(config.Kafka.Brokers[1], "1.1.1.1:9092")
 	is.Equal(config.Kafka.ConsumerGroup, "consumer-group")
 	is.Equal(config.Kafka.InputTopic, "input-topic")
-	is.Equal(config.EndIfIdleDuration, 1*time.Minute)
+	is.Equal(config.Kafka.EventTopic, "events")
+
+	is.Equal(config.Engine.ID, "engine1")
+	is.Equal(config.Engine.InstanceID, "instance1")
+	is.Equal(config.Engine.EndIfIdleDuration, 1*time.Minute)
 	is.Equal(config.Stdout, os.Stdout)
 	is.Equal(config.Stderr, os.Stderr)
 	is.Equal(config.Subprocess.Arguments, os.Args[1:])
@@ -37,4 +45,7 @@ func TestNewConfig(t *testing.T) {
 	is.Equal(config.Webhooks.Backoff.MaxRetries, 3)
 	is.Equal(config.Webhooks.Backoff.InitialBackoffDuration, 100*time.Millisecond)
 	is.Equal(config.Webhooks.Backoff.MaxBackoffDuration, 1*time.Second)
+
+	// events
+	is.Equal(config.Events.PeriodicUpdateDuration, 1*time.Minute)
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -172,7 +172,6 @@ func (e *Engine) processMessage(ctx context.Context, msg *sarama.ConsumerMessage
 		now := time.Now()
 		e.addProcessingTime(now.Sub(start))
 	}()
-
 	var typeCheck struct {
 		Type messageType
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -20,8 +20,9 @@ import (
 // Engine consumes messages and calls webhooks to
 // fulfil the requests.
 type Engine struct {
-	producer Producer
-	consumer Consumer
+	producer      Producer
+	eventProducer Producer
+	consumer      Consumer
 
 	testMode bool
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -324,12 +324,14 @@ func (e *Engine) ready(ctx context.Context) error {
 	}
 }
 
+// ProcessingDuration gets the current processing duration.
 func (e *Engine) ProcessingDuration() time.Duration {
 	e.processingDurationLock.RLock()
 	defer e.processingDurationLock.RUnlock()
 	return e.processingDuration
 }
 
+// addProcessingTime adds the d to the current processing duration.
 func (e *Engine) addProcessingTime(d time.Duration) {
 	e.processingDurationLock.Lock()
 	defer e.processingDurationLock.Unlock()

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -273,7 +273,7 @@ func TestEndIfIdleDuration(t *testing.T) {
 	defer cancel()
 	engine := NewEngine()
 	engine.Config.Subprocess.Arguments = []string{} // no subprocess
-	engine.Config.EndIfIdleDuration = 100 * time.Millisecond
+	engine.Config.Engine.EndIfIdleDuration = 100 * time.Millisecond
 	inputPipe := newPipe()
 	defer inputPipe.Close()
 	outputPipe := newPipe()

--- a/engine/events.go
+++ b/engine/events.go
@@ -80,6 +80,10 @@ func (e *Engine) sendEvent(evt event) {
 }
 
 func (e *Engine) sendPeriodicEvents(ctx context.Context) {
+	if e.Config.Events.PeriodicUpdateDuration == 0 {
+		e.logDebug("(skipping) sendPeriodicEvents because Config.Events.PeriodicUpdateDuration == 0")
+		return
+	}
 	start := time.Now()
 	for {
 		select {

--- a/engine/events.go
+++ b/engine/events.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/Shopify/sarama"
+)
+
+const (
+	eventType = "edge_event_data"
+
+	// eventConsumed event when consumed a Kafka message from its engine topic
+	eventConsumed = "media_chunk_consumed"
+	// eventProduced (or ChunkProcessedStatusProduced or EngineOutputProduced) event when producing a Kafka message to chunk_all topic
+	eventProduced = "chunk_result_produced"
+	// eventStart when engine instance is ready to process work
+	eventStart = "engine_instance_ready"
+	// eventStop when engine instance gracefully shutdown
+	eventStop = "engine_instance_quit"
+	// eventPeriodic event reporting total time (rounded to nearest second) engine instance has been and total time processing
+	eventPeriodic = "engine_instance_up_periodic"
+)
+
+// event
+type event struct {
+	// Key for the topic
+	Key string
+	// Type of the event should be one of the constants
+	Type string
+
+	// produce/consume/periodic
+	JobID  string
+	TaskID string
+
+	// produce/consume
+	ChunkID string
+
+	// periodic
+	ProcessingDurationSecs int64
+	UpDurationSecs         int64
+}
+
+// sendEvent produces an event with fire and forget policy
+func (e *Engine) sendEvent(evt event) {
+	buildID := strings.Replace(e.Config.Kafka.ChunkTopic, "chunk_in_", "", -1)
+
+	now := int64(time.Now().UTC().UnixNano() / 1e6)
+	edgeEvt := edgeEvent{
+		Type:         eventType,
+		TimestampUTC: now,
+		EventTimeUTC: now,
+		Component:    e.Config.Engine.ID,
+		EngineInfo: &EngineInfo{
+			EngineID:               e.Config.Engine.ID,
+			InstanceID:             e.Config.Engine.InstanceID,
+			BuildID:                buildID,
+			ProcessingDurationSecs: evt.ProcessingDurationSecs,
+			UpDurationSecs:         evt.UpDurationSecs,
+		},
+		Event:   evt.Type,
+		JobID:   evt.JobID,
+		TaskID:  evt.TaskID,
+		ChunkID: evt.ChunkID,
+	}
+
+	_, _, err := e.producer.SendMessage(&sarama.ProducerMessage{
+		Topic: e.Config.Kafka.EventTopic,
+		Key:   sarama.ByteEncoder(evt.Key),
+		Value: newJSONEncoder(edgeEvt),
+	})
+	if err != nil {
+		e.logDebug("WARN", "failed to produce engine event:", err, evt)
+	}
+}
+
+func (e *Engine) sendPeriodicEvents(ctx context.Context) {
+	start := time.Now()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(e.Config.Events.PeriodicUpdateDuration):
+			now := time.Now()
+			e.sendEvent(event{
+				Key:                    e.Config.Engine.ID,
+				Type:                   eventPeriodic,
+				UpDurationSecs:         int64(now.Sub(start).Seconds()),
+				ProcessingDurationSecs: int64(e.ProcessingDuration().Seconds()),
+			})
+		}
+	}
+}
+
+// edgeEvent is the contract to send the data to kafka
+type edgeEvent struct {
+	Type         string      `json:"type,omitempty"`         // EdgeEventDataType (required)
+	TimestampUTC int64       `json:"timestampUTC,omitempty"` // TimestampUTC is time this message created in epoch millisecs (optional)
+	Event        string      `json:"event,omitempty"`        // Event is one of Edge events listed above (required)
+	EventTimeUTC int64       `json:"eventTimeUTC,omitempty"` // EventTimeUTC is time that event occurred in epoch millisecs (required)
+	Component    string      `json:"component,omitempty"`    // Component is service name or EngineID that generated the event (required)
+	JobID        string      `json:"jobId,omitempty"`        // JobID this event is associated with (required, except for EngineInstance* events)
+	TaskID       string      `json:"taskId,omitempty"`       // TaskID this event is associated with (required, except for EngineInstance* events)
+	ChunkID      string      `json:"chunkId,omitempty"`      // ChunkID this event is associated with (required, except for GQLCall, ChunkEOF, GenericEvent, RunTask, and EngineInstance events)
+	EngineInfo   *EngineInfo `json:"engineInfo,omitempty"`   // EngineInfo required only for EngineInstance events
+}
+
+// EngineInfo contains contextual data for EngineInstance* events
+type EngineInfo struct {
+	EngineID               string `json:"engineId,omitempty"`               // EngineID of instance (required)
+	BuildID                string `json:"buildId,omitempty"`                // BuildID of instance (required)
+	InstanceID             string `json:"instanceId,omitempty"`             // InstanceID is unique ID of instance (either AWS Task ID or random UUID) (required)
+	UpDurationSecs         int64  `json:"upDurationSecs,omitempty"`         // UpDurationSecs Required only for EngineInstancePeriodic event, contains engine up time in seconds
+	ProcessingDurationSecs int64  `json:"processingDurationSecs,omitempty"` // ProcessingDurationSecs required only for EngineInstancePeriodic event, contains engine processing time in seconds
+}

--- a/engine/events.go
+++ b/engine/events.go
@@ -24,21 +24,19 @@ const (
 	eventPeriodic = "engine_instance_up_periodic"
 )
 
-// event
+// event is an event that is sent to the platform.
 type event struct {
 	// Key for the topic
 	Key string
 	// Type of the event should be one of the constants
 	Type string
 
-	// produce/consume/periodic
-	JobID  string
-	TaskID string
-
-	// produce/consume
+	// for produce/consume events
+	JobID   string
+	TaskID  string
 	ChunkID string
 
-	// periodic
+	// for periodic events
 	ProcessingDurationSecs int64
 	UpDurationSecs         int64
 }
@@ -79,6 +77,8 @@ func (e *Engine) sendEvent(evt event) {
 	}
 }
 
+// sendPeriodicEvents sends the periodic events.
+// Cancellable via the context.
 func (e *Engine) sendPeriodicEvents(ctx context.Context) {
 	if e.Config.Events.PeriodicUpdateDuration == 0 {
 		e.logDebug("(skipping) sendPeriodicEvents because Config.Events.PeriodicUpdateDuration == 0")

--- a/engine/kafka.go
+++ b/engine/kafka.go
@@ -153,7 +153,7 @@ type chunkResult struct {
 	EngineOutput *mediaChunkMessage `json:"engineOutput,omitempty"`
 
 	ErrorMsg      string `json:"errorMsg,omitempty"`
-	FailureReason string `json:"failureReason,omitempty`
+	FailureReason string `json:"failureReason,omitempty"`
 	FailureMsg    string `json:"failureMsg,omitempty"`
 }
 

--- a/engine/main.go
+++ b/engine/main.go
@@ -71,6 +71,8 @@ func run(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "kafka producer")
 		}
+		// use the same producer for events
+		eng.eventProducer = eng.producer
 	} else {
 		eng.logDebug("skipping kafka setup")
 	}


### PR DESCRIPTION
This work was based on https://github.com/veritone/engine-toolkit/pull/25 - thanks to @neovinhtru @tnguyen-veri et al. 

---

This PR sends start, stop, periodic, produced and consumed messages, and includes a timer for elapsed processing time.

## test: Running example

Nudebox has been deployed to stage, where it may now be tested.

Engine ID: `a069d59e-8f16-4d41-ad8b-182d2367368f`
Build ID: `40c5b781-26b7-4de5-9998-c044acf49169`